### PR TITLE
Hotfix/5.1.1

### DIFF
--- a/src/app/plugins/acf-address/acf-address-v5.php
+++ b/src/app/plugins/acf-address/acf-address-v5.php
@@ -254,6 +254,30 @@ class acf_field_address extends acf_field {
     return $field;
   }
 
+  public function load_value($value, $post_id, $field) {
+    $new_value = [];
+    foreach($value as $k => $v) {
+      switch($k) {
+        case 'address1':
+          $new_value['street1'] = $v;
+          break;
+        case 'address2':
+          $new_value['street2'] = $v;
+          break;
+        case 'address3':
+          $new_value['street3'] = $v;
+          break;
+        case 'postal_code':
+          $new_value['zip'] = $v;
+          break;
+        default:
+          $new_value[$k] = $v;
+      }
+    }
+
+    return $new_value;
+  }
+
   /**
    * This function is for backwards compatibility with php version 5.3
    * @param $val


### PR DESCRIPTION
load_field no longer does what it used to do. I am unsure when exactly this change occurred.

This hotfix might require acf version 5.3.6 or later.
