### PR TITLE
Fixed unicode characters were escaped on render field.

### DIFF
--- a/src/app/plugins/acf-address/acf-address-v5.php
+++ b/src/app/plugins/acf-address/acf-address-v5.php
@@ -145,7 +145,7 @@ class acf_field_address extends acf_field {
 
     <div class="acf-address-field"
          data-name="<?php echo $field['name']; ?>"
-         data-value="<?php echo esc_js( json_encode( $field['value'] ) ); ?>"
+         data-value="<?php echo esc_js( json_encode( $field['value'], JSON_UNESCAPED_UNICODE ) ); ?>"
          data-output-type="<?php echo $field['output_type']; ?>"
          data-layout="<?php echo esc_js( $address_layout ); ?>"
          data-options="<?php echo esc_js( $address_options ); ?>"


### PR DESCRIPTION
## Issue
Unicode characters (e.g. German umlauts, accents, etc.) are escaped and so are wrongly rendered.

## How to reproduce the issue
Insert a word containing accents in the `Street 1` field (or whatever other address field) and save it.
For example, inseriting `Carrer de Salvà` the field renders `Carrer de Salvu00e0`.

## Proposed solution
Since the field is correctly saved in the DB but wrongly rendered, we can specify `JSON_UNESCAPED_UNICODE` in the `json_encode` at the moment of the render.

## Notes
This will solve an open issue: https://github.com/strickdj/acf-field-address/issues/22